### PR TITLE
Update networkSecurityGroup for X1 interface

### DIFF
--- a/azureDeploy.json
+++ b/azureDeploy.json
@@ -444,6 +444,9 @@
       },
       "properties": {
         "enableIPForwarding": true,
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgname-mgmt'))]"
+        },
         "ipConfigurations": [
           {
             "name": "[concat('ipconfig', '1')]",

--- a/mainTemplate.json
+++ b/mainTemplate.json
@@ -438,6 +438,9 @@
       },
       "properties": {
         "enableIPForwarding": true,
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgname-mgmt'))]"
+        },
         "ipConfigurations": [
           {
             "name": "[concat('ipconfig', '1')]",


### PR DESCRIPTION
[GEN7-28269](https://track.eng.sonicwall.com/browse/GEN7-28269) Deploying NSv in Azure to existing VNET does not associate NSG to X1 WAN Subnet